### PR TITLE
#165787247 Build the get Current and get Repaid Loan endpoint 

### DIFF
--- a/server/src/controllers/loanController.js
+++ b/server/src/controllers/loanController.js
@@ -3,7 +3,12 @@ import data from '../mocks/mockData';
 const { loans } = data;
 
 export default class LoanController {
-  static async getAll (req, res) {
+  static async getAll (req, res, next) {
+    const { status, repaid } = req.query;
+
+    if(status && status) {
+      return next() 
+    }
     if (loans.length <= 0) {
       return res.status(404).json({
         status: 404,
@@ -32,5 +37,27 @@ export default class LoanController {
       status: 200,
       data: loan,
     });
+  }
+
+  static async currentRepaid (req, res) {
+    const status = req.query.status;
+    const repaid = JSON.parse(req.query.repaid);
+    const repaidUnrepaid = loans.filter(existingLoan => existingLoan.status === status && existingLoan.repaid === repaid)
+
+    if(repaidUnrepaid.length <= 0 && repaid === false) {
+      return res.status(404).json({
+        status: 404,
+        error: 'No current loan!',
+      });
+    } else if (repaidUnrepaid.length <= 0 && repaid === true) {
+      return res.status(404).json({
+        status: 404,
+        error: 'No repaid loan!',
+      });
+    }
+    return res.status(200).json({
+      status: 200,
+      data: repaidUnrepaid,
+    })
   }
 }

--- a/server/src/middlewares/queryValidator.js
+++ b/server/src/middlewares/queryValidator.js
@@ -1,0 +1,25 @@
+import Validator from 'validatorjs';
+import customErrorMsgs from '../helpers/customErrorMsgs';
+
+export default class QueryValidator {
+  static async validateQuery (req, res, next) {
+    const query = req.query;
+
+    const queryProperties = {
+      status: 'in:approved',
+      repaid: 'boolean|required_if:status,approved'
+    }
+
+    const validator = new Validator(query, queryProperties, customErrorMsgs);
+
+    validator.passes(() => next());
+    validator.fails(() => {
+      const errors = validator.errors.all();
+      return res.status(400).json({
+        status: 400,
+        error: errors,
+      });
+    })
+
+  }
+}

--- a/server/src/routes/loanRoutes.js
+++ b/server/src/routes/loanRoutes.js
@@ -2,15 +2,18 @@ import { Router } from 'express';
 import LoanController from '../controllers/loanController';
 import Access from '../middlewares/access';
 import ParamsValidator from '../middlewares/paramsValidator';
+import QueryValidator from '../middlewares/queryValidator'
 
 const { verifyToken, adminAccess } = Access;
-const { loanId} = ParamsValidator;
+const { loanId } = ParamsValidator;
+const { validateQuery } = QueryValidator
 
-const { getAll, getSpecificLoan } = LoanController;
+const { getAll, getSpecificLoan, currentRepaid } = LoanController;
 
 const loanRoute = new Router();
 
-loanRoute.get('/', verifyToken, adminAccess, getAll);
+loanRoute.get('/', verifyToken, adminAccess, getAll, validateQuery, currentRepaid);
 loanRoute.get('/:loanId', verifyToken, adminAccess, loanId, getSpecificLoan);
+
 
 export default loanRoute;

--- a/server/src/test/loanTest.js
+++ b/server/src/test/loanTest.js
@@ -7,7 +7,7 @@ chai.use(chaiHttp);
 
 const { expect } = chai;
 const { adminUser, existingUserSignIn } = authTestData;
-const { invalidLoanId } = loanTestData
+const { invalidLoanId, invalidQueryParams } = loanTestData
 
 let adminToken;
 let userToken;
@@ -88,5 +88,29 @@ describe('LOANS TEST', () => {
       expect(res).to.have.status(200);
       expect(res.body).to.have.property('data');
     })
+
+    describe('GET REPAID  AND CURRENT LOANS', () => {
+      it('should return a status 200 and return all repaid loans', async () => {
+        const res = await chai.request(app)
+        .get('/api/v1/loans?status=approved&repaid=true')
+        .set('x-access-token', adminToken)
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.property('data');
+      });
+      it('should return a status 200 and return all current loans', async () => {
+        const res = await chai.request(app)
+        .get('/api/v1/loans?status=approved&repaid=false')
+        .set('x-access-token', adminToken)
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.property('data');
+      });
+      it('should return a status 400 when query validation fails', async () => {
+        const res = await chai.request(app)
+        .get(`/api/v1/loans?${invalidQueryParams}`)
+        .set('x-access-token', adminToken)
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.property('error');
+      })
+    });
   })
 });

--- a/server/src/test/testData.js
+++ b/server/src/test/testData.js
@@ -44,5 +44,6 @@ const userTestData = {
 
 const loanTestData = {
   invalidLoanId: 'cat',
+  invalidQueryParams: 'status=rejected&repaid=true',
 }
 export { authTestData, userTestData, loanTestData };


### PR DESCRIPTION
#### What does this PR do?
Implement get repaid and get unrepaid loan endpoint 
#### Description of Task to be completed?
- Write test for the endpoint 
- Refactor the GET /api/v1/loans endpoint to use the get current and repaid loan controller
- Add Query validation middleware
#### How should this be manually tested?
After cloning the repo, `cd` into it and type `npm start` in the command line
Using Postman, test the above endpoint by sending a GET request to the above endpoint specifying the query
- Get current loans query `?status=approved&repaid=false`
- Get repaid loans query `?status=approved&repaid=true`
#### What are the relevant pivotal tracker stories?
#165787247, #165787544 